### PR TITLE
Editorial: Change the status code of an example.

### DIFF
--- a/draft-pardue-http-identity-digest.md
+++ b/draft-pardue-http-identity-digest.md
@@ -196,7 +196,7 @@ Range: bytes=0-10
 ~~~ http-message
 NOTE: '\' line wrapping per RFC 8792
 
-HTTP/1.1 200 OK
+HTTP/1.1 206 Partial Content
 Content-Encoding: gzip
 Content-Digest: \
   sha-256=:SotB7Pa5A7iHSBdh9mg1Ev/ktAzrxU4Z8ldcCIUyfI4=:


### PR DESCRIPTION
Range requests should return 206 responses, not 200.

They should also include headers like `Content-Range` and etc, but that seems like overkill for this example. The status code, however, seems like just the right amount of pedantry.