### PR TITLE
Requiring processing presents a new security consideration

### DIFF
--- a/draft-pardue-httpbis-identity-digest.md
+++ b/draft-pardue-httpbis-identity-digest.md
@@ -299,7 +299,7 @@ Unencoded-Digest: \
 The considerations in {{DIGEST-FIELDS}} apply.
 
 HTTP messages can contain both Content-Encoding and Unencoded-Digest
-({{encoding-and-unencoded}}). In order to validate the unencoded-digest, encoded
+({{encoding-and-unencoded}}). In order to validate the Unencoded-Digest, encoded
 content would need to be decoded. The might offer the opportunity for an
 attacker to direct malicious data into a decoder. One possible mitigation would
 be to also provide a Content-Digest or Repr-Digest in the message, allowing for

--- a/draft-pardue-httpbis-identity-digest.md
+++ b/draft-pardue-httpbis-identity-digest.md
@@ -209,7 +209,7 @@ Want-Unencoded-Digest: sha-256=1
 Want-Unencoded-Digest: sha-512=3, sha-256=10, unixsum=0
 ~~~
 
-# Messages containing both Unencoded-Digest and Content-Encoding
+# Messages containing both Unencoded-Digest and Content-Encoding {#encoding-and-unencoded}
 
 Digests delivered through `Unencoded-Digest` apply to the unencoded representation. If a message is
 received with content coding, a recipient needs to decode the message in order
@@ -296,8 +296,16 @@ Unencoded-Digest: \
 
 # Security Considerations
 
-The considerations in {{DIGEST-FIELDS}} apply. There are no known additional
-considerations.
+The considerations in {{DIGEST-FIELDS}} apply.
+
+HTTP messages can contain both Content-Encoding and Unencoded-Digest
+({{encoding-and-unencoded}}). In order to validate the unencoded-digest, encoded
+content would need to be decoded. The might offer the opportunity for an
+attacker to direct malicious data into a decoder. One possible mitigation would
+be to also provide a Content-Digest or Repr-Digest in the message, allowing for
+validation of the received bytes before further processing. Furthermore, the use
+of signatures as explained in {{Section 6.3 of DIGEST-FIELDS}} can address data
+substitution attacks.
 
 
 # IANA Considerations

--- a/draft-pardue-httpbis-identity-digest.md
+++ b/draft-pardue-httpbis-identity-digest.md
@@ -296,16 +296,18 @@ Unencoded-Digest: \
 
 # Security Considerations
 
-The considerations in {{DIGEST-FIELDS}} apply.
+All the same considerations documented in {{DIGEST-FIELDS}} apply.
 
-HTTP messages can contain both Content-Encoding and Unencoded-Digest
-({{encoding-and-unencoded}}). In order to validate the Unencoded-Digest, encoded
-content would need to be decoded. The might offer the opportunity for an
-attacker to direct malicious data into a decoder. One possible mitigation would
-be to also provide a Content-Digest or Repr-Digest in the message, allowing for
-validation of the received bytes before further processing. Furthermore, the use
-of signatures as explained in {{Section 6.3 of DIGEST-FIELDS}} can address data
-substitution attacks.
+This document introduces a further consideration related to the process of
+validation when an HTTP message contains both Content-Encoding and
+Unencoded-Digest ({{encoding-and-unencoded}}). In order to validate the
+Unencoded-Digest, encoded content needs to be decoded. This provides an
+opportunity for an attacker to direct malicious data into a decoder. One
+possible mitigation would be to also provide a Content-Digest or Repr-Digest in
+the message, allowing for validation of the received bytes before further
+processing. An attacker that can substitute various parts of an HTTP message
+presents several risks, {{Sections 6.1, 6.2 and 6.3 of DIGEST-FIELDS}}
+describe relevant considerations and mitigations.
 
 
 # IANA Considerations


### PR DESCRIPTION
I'm not convinced if this is a credible threat or not but it seems worthwhile to highlight since the unencoded digest requires different handling that we talked about in RFC 9530.

As always, signing things reduces the vectors where content substitution might happen.